### PR TITLE
Add option to use ssh agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ let config = {
   port: 22,                       // Optional. Default to 22
   username: 'user',               // Required.
   password: 'password',           // Optional.
-  privateKey: '/pass/to/key.pem', // Optional.
+  privateKey: '/path/to/key.pem', // Optional.
   passphrase: 'passphrase',       // Optional.
+  agent: '/path/to/agent.sock',   // Optional, path to the ssh-agent socket.
   localDir: 'dist',               // Required. Absolute or relative to cwd
-  remoteDir: '/pass/to/dest'      // Required. Absolute path only.
+  remoteDir: '/path/to/dest'      // Required. Absolute path only.
 };
 
 let options = {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,6 +5,7 @@ export interface SftpSyncConfig {
   password?: string;
   privateKey?: string;
   passphrase?: string;
+  agent?: string;
   localDir: string;
   remoteDir: string;
 }

--- a/lib/sftpSync.ts
+++ b/lib/sftpSync.ts
@@ -101,7 +101,8 @@ export class SftpSync {
           username: this.config.username,
           password: this.config.password,
           passphrase: this.config.passphrase,
-          privateKey: privKeyRaw
+          privateKey: privKeyRaw,
+          agent: this.config.agent
         });
       });
     });


### PR DESCRIPTION
Simple patch to allow use of ssh-agent.

This is useful for passwordless key set-ups.