### PR TITLE
add: removeExtraFiles on remote is configurable behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ let options = {
     'src/**/*.spec.ts'
   ],
   excludeMode: 'remove',          // Behavior for excluded files ('remove' or 'ignore'), Default to 'remove'.
-  forceUpload: false              // Force uploading all files, Default to false(upload only newer files).
+  forceUpload: false,              // Force uploading all files, Default to false(upload only newer files).
+  removeExtraFiles: false          // Remove files on the target that are not present on the source or in the exclude list. Defaults to true.
 };
 
 deploy(config, options).then(() => {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -15,4 +15,5 @@ export interface SftpSyncOptions {
   exclude?: string[];
   excludeMode?: 'ignore'|'remove';
   forceUpload?: boolean;
+  removeExtraFiles?: boolean;
 }

--- a/lib/sftpSync.ts
+++ b/lib/sftpSync.ts
@@ -57,7 +57,8 @@ export class SftpSync {
     this.options = Object.assign({
       dryRun: false,
       exclude: [],
-      excludeMode: 'remove'
+      excludeMode: 'remove',
+      removeExtraFiles: true
     }, options);
 
     this.client = new Client;

--- a/lib/syncTable.ts
+++ b/lib/syncTable.ts
@@ -43,7 +43,7 @@ export class SyncTableEntry {
       task.hasError = true;
     }
 
-    if (this.remoteStat !== null && !task.hasError && this.localStat !== this.remoteStat) {
+    if (this.remoteStat !== null && !task.hasError && this.localStat !== this.remoteStat && options.removeExtraFiles) {
       task.removeRemote = true;
     }
 


### PR DESCRIPTION
This flag can be useful especially when you are not deploying a code but you upload data files, for instance, and you want to keep original files in the target folder.
