### PR TITLE
Update ssh2 dependency to version 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chalk": "^2.3.0",
     "minimatch": "^3.0.3",
     "queue": "^5.0.0",
-    "ssh2": "^0.5.4"
+    "ssh2": "^1.4.0"
   },
   "devDependencies": {
     "typescript": "^2.7.1"


### PR DESCRIPTION
所依赖的 ssh2 因为版本过低，存在漏洞，特此升级，详情参考：[#15](https://github.com/lucascaro/hexo-deployer-sftp/issues/15)